### PR TITLE
Allow concrete changes to be suggested by a pull request

### DIFF
--- a/comment_help.md
+++ b/comment_help.md
@@ -6,23 +6,23 @@ description: "Guide on providing feedback"
 
 # Providing Feedback
 
-1. **Review the documentation.** No account is needed to review the updated version of NIST SP 800-63-3. Simply follow this link and enjoy at your leisure. However, if you wish to comment you must…
+**Review the documentation.** No account is needed to review the updated version of NIST SP 800-63-3. Simply follow [this link](https://github.com/usnistgov/800-63-3) and enjoy at your leisure. However, if you wish to comment you must…
 
-2. **Establish a GitHub account.** In order to submit a comment through the GitHub “Issues” feature, you will need to create a GitHub account. This can be done by proceeding to [https://github.com/join](). GitHub allows you to remain pseudonymous if you would like, just make sure you select the options that suit you on the “Profile” and “Emails” pages of your “Personal Settings”.  We also highly encourage you to turn on two-factor authentication in the “Security” page, also part of “Personal Settings”.  
-  ![](assets/create_github_account.png)
+1. **Establish a GitHub account.** In order to submit a comment through the GitHub “Issues” feature, you will need to create a GitHub account. This can be done by proceeding to https://github.com/join. GitHub allows you to remain pseudonymous if you would like, just make sure you select the options that suit you on the “Profile” and “Emails” pages of your “Personal Settings”.  We also highly encourage you to turn on two-factor authentication in the “Security” page, also part of “Personal Settings”.  
+  ![How to create account](assets/create_github_account.png)
 
-3. **Open an issue.** As you are reading and identify comments you would like to make:
+2. **Open an issue.** As you are reading and identify comments you would like to make:
 
     1. Click on either the "Comment" link in the sidebar navigation or the "Send Feedback" link in the footer of the page.
 
     2. Click on the "New Issue" button in the upper right of the screen.  
-    ![](assets/create_new_issue.png)
+    ![Create issue](assets/create_new_issue.png)
 
     3. When the “Issue Page” opens, you will be presented with several labels based on the sections of the document, select the one that applies to your comment.  
-    ![](assets/issue_apply_label.png)
+    ![Apply label](assets/issue_apply_label.png)
 
     4. Provide a short description in the field labelled "Title" for the feedback being provided.  
-    ![](assets/issue_title.png)
+    ![Issue title](assets/issue_title.png)
 
     5. Within the field labelled "Leave a comment", fill out the comment template and provide as much information as possible.
 
@@ -41,8 +41,9 @@ description: "Guide on providing feedback"
             Organization: 1 = Federal, 2 = Industry, 3 = Other
 
     6. Hit “Submit New Issue” and you are done!  
-    ![](assets/submit_new_issue.png)
+    ![Submit issue](assets/submit_new_issue.png)
 
     7. If you want to keep up with others comments through email and monitor future changes, make sure you choose to “Watch” the project!  
-    ![](assets/watch_project.png)
+    ![Watch project](assets/watch_project.png)
 
+If you are familiar with github you are also welcome to provide suggestions to concrete changes as a pull request. Please provide information about organization and a rationale for suggested change.


### PR DESCRIPTION
The force of github is its ability to facilitate dialogue about changes based on the change itself. 

Asking for inputs and feedback exclusively as a (well described) issue discards concrete suggestsions to the text in the form of a pull request. 

Pull requests facilitates debate and discussion based on each change and - by that - supports a more fruitful dialogue. Also, having dialogue about concrete changes in a pull request will make it easy to track down what dialogue went into a specific change to a text.

A good case is issue #157 where adding the word `acoustic` seams well documented but its not easy for the reader to see the change in context without searching for the exact document and location. With #157 suggested as a pull request it would be easy understand the implications for the whole paragraph. 

I suggest that the documentation on how to provide feedback is extended with information describing that concrete changes may be suggested by a pull request if prefered.
