### PR TITLE
Add "acoustic" to definition of Side Channel Attack 

### DIFF
--- a/sp800-63b/sec3_definitions.md
+++ b/sp800-63b/sec3_definitions.md
@@ -274,7 +274,7 @@ An attack in which the attacker is able to insert himself or herself between a c
 A secret used in authentication that is known to the claimant and the verifier.
 
 #### Side Channel Attack
-An attack enabled by leakage of information from a physical cryptosystem. Timing, power consumption, and electromagnetic emissions are examples of characteristics that could be exploited in a side-channel attack.
+An attack enabled by leakage of information from a physical cryptosystem. Timing, power consumption, electromagnetic and acoustic emissions are examples of characteristics that could be exploited in a side-channel attack.
 
 #### Social Engineering
 The act of deceiving an individual into revealing sensitive information by associating with the individual to gain confidence and trust.


### PR DESCRIPTION
Concrete change suggested in #157

> The definition of side channel attacks should explicitly mention acoustic emissions, since these have been demonstrated to be exploitable for cryptographic key extraction. Specifically [1][2] show non-invasive side channel attacks that extract RSA keys from widely-deployed software implementations, via acoustic emissions, using inexpensive equipment.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/usnistgov/800-63-3/163)

<!-- Reviewable:end -->
