### PR TITLE
Fix formatting bug in 800-63C Section 8

### DIFF
--- a/sp800-63c/sec8_security.md
+++ b/sp800-63c/sec8_security.md
@@ -94,15 +94,15 @@ described in the last subsection.
 -   *Assertion manufacture/modification*: To mitigate this threat,
     the following mechanisms are used:
 
-  	1.  The assertion is digitally signed by the CSP. The RP 
+	1.  The assertion is digitally signed by the CSP. The RP 
     checks the digital signature to verify that it was issued by a
     legitimate CSP.
 
-    2.  The assertion is sent over a protected session such as TLS. In
+	2.  The assertion is sent over a protected session such as TLS. In
     order to protect the integrity of assertions from malicious attack,
     the CSP is authenticated.
 
-    3. The assertion contains a non-guessable random identifier. 
+	3. The assertion contains a non-guessable random identifier. 
 
 -   *Assertion disclosure* – To mitigate this threat, one of the
     following mechanisms are used:


### PR DESCRIPTION
An indentation issue is causing part of this list to be treated as a code block.

![screenshot 2016-07-28 15 46 45](https://cloud.githubusercontent.com/assets/81445/17232131/e8454aca-54da-11e6-888d-7b78f1017848.png)

This change updates the indentation of the affected lines to match the rest of the file.
