### PR TITLE
Updated root README to point to sub-READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 
 The repository is for the active development of a proposed new model for a NIST 800 series Special Publication: 
 
-* [SP 800-63-3](sp800-63-3/cover.md): Digital Authentication Guideline
-* [SP 800-63A](sp800-63a/cover.md): Enrollment and Identity Proofing
-* [SP 800-63B](sp800-63b/cover.md): Authentication and Lifecycle Management
-* [SP 800-63C](sp800-63c/cover.md): Federation and Assertions
+* [SP 800-63-3](sp800-63-3/README.md): Digital Authentication Guideline
+* [SP 800-63A](sp800-63a/README.md): Enrollment and Identity Proofing
+* [SP 800-63B](sp800-63b/README.md): Authentication and Lifecycle Management
+* [SP 800-63C](sp800-63c/README.md): Federation and Assertions
  
 Full HTML version can be viewed at https://pages.nist.gov/800-63-3
 


### PR DESCRIPTION
Currently, the root README provides links to the `cover.md` for the four SP 800 documents contained in this repository. Those Markdown files seem to be used to generate the cover, executive summary, and table of contents for the [HTML version](https://pages.nist.gov/800-63-3/sp800-63-3.html) of the documents available at pages.nist.gov. Linking to those files from the main README is problematic because they utilize various non-vanilla Markdown syntax that GitHub's Markdown compiler does not handle gracefully. Therefore, it makes more sense to link to the README files which contain a brief description of the document and the table of contents, including a link to the frontmatter (i.e. `cover.md`).
