### PR TITLE
Changes the README files so the links work on github

### DIFF
--- a/sp800-63a/README.md
+++ b/sp800-63a/README.md
@@ -1,5 +1,5 @@
 # SP 800-63A
 
-This is a working draft of NIST Special Publication 800-63A *Identity Proofing*. This document is a sub-document referenced by [SP 800-63-3](../sp800-63-3/README.html) covering the associated topics that had been previously in SP 800-63-2.
+This is a working draft of NIST Special Publication 800-63A *Identity Proofing*. This document is a sub-document referenced by [SP 800-63-3](../sp800-63-3/README.md) covering the associated topics that had been previously in SP 800-63-2.
 
 SP 800-63A deals with the processes by which an individual can prove their identity to a CSP prior to credential issuance.

--- a/sp800-63b/README.md
+++ b/sp800-63b/README.md
@@ -12,26 +12,26 @@ SP 800-63B provides guidance on the selection, use, and management of authentica
 
 This document is broken up into sections as follows:
 
-[Front matter](front.html)
+[Front matter](front.md)
 
-[1. Purpose and 2. Introduction](sec1_2_introduction.html)
+[1. Purpose and 2. Introduction](sec1_2_introduction.md)
 
-[3. Definitions and Abbreviations](sec3_definitions.html)
+[3. Definitions and Abbreviations](sec3_definitions.md)
 
-[4. Authenticator Assurance Levels](sec4_aal.html)
+[4. Authenticator Assurance Levels](sec4_aal.md)
 
-[5. Authenticator and Verifier Requirements](sec5_authenticators.html)
+[5. Authenticator and Verifier Requirements](sec5_authenticators.md)
 
-[6. Authenticator Lifecycle Management](sec6_lifecycle.html)
+[6. Authenticator Lifecycle Management](sec6_lifecycle.md)
 
-[7. Session Management](sec7_session.html)
+[7. Session Management](sec7_session.md)
 
-[8. Threats and Security Considerations](sec8_security.html)
+[8. Threats and Security Considerations](sec8_security.md)
 
-[9. Privacy Considerations](sec9_privacy.html)
+[9. Privacy Considerations](sec9_privacy.md)
 
-[10. Usability Considerations](sec10_usability.html)
+[10. Usability Considerations](sec10_usability.md)
 
-[11. References](references.html)
+[11. References](references.md)
 
-[Appendix A. Strength of Memorized Secrets](appA_memorized.html)
+[Appendix A. Strength of Memorized Secrets](appA_memorized.md)

--- a/sp800-63c/README.md
+++ b/sp800-63c/README.md
@@ -1,6 +1,6 @@
 # SP 800-63C
 
-This is a working draft of NIST Special Publication 800-63C, *Assertions and Federation*. This document is a sub-document referenced by [SP 800-63-3](../sp800-63-3/README.html) covering the associated topics that had been previously in SP 800-63-2.
+This is a working draft of NIST Special Publication 800-63C, *Assertions and Federation*. This document is a sub-document referenced by [SP 800-63-3](../sp800-63-3/README.md) covering the associated topics that had been previously in SP 800-63-2.
 
 SP 800-63C provides guidance on the use of assertions to convey the results of authentication processes to a relying party. Assertions are used in federated identity systems where the authentication is performed a verifier (sometimes called an Identity Provider) and used by a different party, sometimes called a Relying Party. Federation permits a centrally-managed set of credentials to be used at a number if different relying parties.
 
@@ -8,32 +8,32 @@ Keys and other secrets used to maintain state (stored in cookies, local storage,
 
 This document is broken up into sections as follows:
 
-[Front matter](front.html)
+[Front matter](front.md)
 
-[1. Purpose and 2. Introduction](sec1_2_introduction.html)
+[1. Purpose and 2. Introduction](sec1_2_introduction.md)
 
-[3. Definitions and Abbreviations](sec3_definitions.html)
+[3. Definitions and Abbreviations](sec3_definitions.md)
 
-[4. Assertion Strength](sec4_strength.html)
+[4. Assertion Strength](sec4_strength.md)
 
     4.1. Bearer assertions
     4.2. Holder of key assertions
 
-[5. Assertion Models](sec5_models.html)
+[5. Assertion Models](sec5_models.md)
 
     5.1 Direct Model
     5.2 Indirect Model
 
-[6. Examples](sec6_examples.html)
+[6. Examples](sec6_examples.md)
 
     6.1. SAML
     6.2. Kerberos
     6.3. OpenID Connect and OAuth
 
-[7. Assertion Threats](sec7_threats.html)
+[7. Assertion Threats](sec7_threats.md)
 
-[8. Privacy Considerations](sec8_privacy.html)
+[8. Privacy Considerations](sec8_privacy.md)
 
-[9. Usability](sec9_usability.html)
+[9. Usability](sec9_usability.md)
 
-[10. References](sec10_references.html)
+[10. References](sec10_references.md)

--- a/sp800-63c/README.md
+++ b/sp800-63c/README.md
@@ -18,9 +18,7 @@ This document is broken up into sections as follows:
 
 [5. Assertion Strength](sec5_strength.md)
 
-[6. Assertion Presentation](sec5_models.md)
-
-[6. Examples](sec6_examples.md)
+[6. Assertion Presentation](sec6_presentation.md)
 
 [7. Federation Assurance Level](sec7_fal.md)
 
@@ -32,4 +30,4 @@ This document is broken up into sections as follows:
 
 [11. Assertion Examples](sec11_examples.md)
 
-[10. References](sec10_references.md)
+[12. References](references.md)

--- a/sp800-63c/README.md
+++ b/sp800-63c/README.md
@@ -14,26 +14,22 @@ This document is broken up into sections as follows:
 
 [3. Definitions and Abbreviations](sec3_definitions.md)
 
-[4. Assertion Strength](sec4_strength.md)
+[4. Federation](sec4_federation.md)
 
-    4.1. Bearer assertions
-    4.2. Holder of key assertions
+[5. Assertion Strength](sec5_strength.md)
 
-[5. Assertion Models](sec5_models.md)
-
-    5.1 Direct Model
-    5.2 Indirect Model
+[6. Assertion Presentation](sec5_models.md)
 
 [6. Examples](sec6_examples.md)
 
-    6.1. SAML
-    6.2. Kerberos
-    6.3. OpenID Connect and OAuth
+[7. Federation Assurance Level](sec7_fal.md)
 
-[7. Assertion Threats](sec7_threats.md)
+[8. Security](sec8_security.md)
 
-[8. Privacy Considerations](sec8_privacy.md)
+[9. Privacy](sec9_privacy.md)
 
-[9. Usability](sec9_usability.md)
+[10. Usability](sec10_usability.md)
+
+[11. Assertion Examples](sec11_examples.md)
 
 [10. References](sec10_references.md)


### PR DESCRIPTION
Closes #212.

**Organization**: Tozny, LLC

**Type**: 2

**Document (63-3, 63A, 63B, or 63C)**: All

**Comment (Include rationale for comment)**:

Perhaps this isn't what you intended, since you may be using these files to generate HTML documents elsewhere, but I noticed that following the links that were displayed in the README files were resulting in 404 errors.
