### PR TITLE
Print view updates

### DIFF
--- a/sp800-63a/cover.md
+++ b/sp800-63a/cover.md
@@ -87,7 +87,9 @@ Technology and Director*
 
 </div>
 
-<div class="breaker text-center" markdown="1">
+<div class="breaker"/>
+
+<div class="text-center" markdown="1">
 
 ### Authority
 
@@ -186,11 +188,9 @@ The terms “CAN” and “CANNOT” indicate a possibility and capability, whet
 
 </div>
 
-<div class="breaker" markdown="1">
+<div class="breaker"/>
 
 ## Executive Summary
-
-</div>
 
 This guideline deals with how an individual, known as an applicant, can prove their identity to a Credential Service Provider (CSP) and become enrolled as a valid subscriber.
 
@@ -208,11 +208,9 @@ At IAL 2, the claimed identity is proven with evidence that supports the real wo
 **IAL 3**:
 At Identity Assurance Level 3, in-person identity proofing is required. Identifying attributes must be verified by an authorized and trained representative of the CSP. As with IAL 2, attributes MAY be asserted by CSPs to RPs in support of pseudonymous identity with verified attributes.
 
-<div class="breaker" markdown="1">
+<div class="breaker"/>
 
 ## Table of Contents
-
-</div>
 
 [1. Purpose](#sec1)
 

--- a/sp800-63a/cover.md
+++ b/sp800-63a/cover.md
@@ -224,8 +224,7 @@ At Identity Assurance Level 3, in-person identity proofing is required. Identify
 
 [5. Identity Resolution, Validation and Verification](#sec5)
 
-[6. Leveraging Antecedent Proofing Events
-](#sec6)
+[6. Leveraging Antecedent Proofing Events](#sec6)
 
 [7. Threats and Security Considerations](#sec7)
 

--- a/sp800-63a/cover.md
+++ b/sp800-63a/cover.md
@@ -1,3 +1,4 @@
+
 <div class="text-right" markdown="1">
 
 # <a name="800-63a"></a> DRAFT NIST Special Publication 800-63A
@@ -15,7 +16,7 @@ Naomi B. Lefkovitz
 Jamie M. Danker  
 
 User Experience Authors:  
-       
+
 Yee-Yin Choong    
 Kristen K. Greene    
 Mary F. Theofanos   
@@ -29,6 +30,8 @@ http://dx.doi.org/10.6028/NIST.SP.XXX
 
 ![](sp800-63-3/media/csd.png)  
 ![](sp800-63-3/media/nist_logo.png)
+
+</div><div class="breaker text-right" markdown="1">
 
 # DRAFT NIST Special Publication 800-63A
 
@@ -84,7 +87,7 @@ Technology and Director*
 
 </div>
 
-<div class="text-center" markdown="1">
+<div class="breaker text-center" markdown="1">
 
 ### Authority
 
@@ -183,7 +186,11 @@ The terms “CAN” and “CANNOT” indicate a possibility and capability, whet
 
 </div>
 
+<div class="breaker">
+
 ## Executive Summary
+
+</div>
 
 This guideline deals with how an individual, known as an applicant, can prove their identity to a Credential Service Provider (CSP) and become enrolled as a valid subscriber.
 
@@ -193,15 +200,19 @@ The three IALs reflect the options agencies may select based on their risk profi
 
 
 **IAL 1**:
-At this level, there is no requirement for an applicant's identity to be proven.  Any attributes provided in conjunction with the authentication process are self-asserted. 
+At this level, there is no requirement for an applicant's identity to be proven.  Any attributes provided in conjunction with the authentication process are self-asserted.
 
 **IAL 2**:
-At IAL 2, the claimed identity is proven with evidence that supports the real world existence of the claimed identity and identifies and verifies the person to whom the claimed identity belongs.  IAL 2 introduces the need for either remote or in-person identity proofing.  Attributes MAY be asserted by CSPs to RPs in support of pseudonymous identity with verified attributes. 
+At IAL 2, the claimed identity is proven with evidence that supports the real world existence of the claimed identity and identifies and verifies the person to whom the claimed identity belongs.  IAL 2 introduces the need for either remote or in-person identity proofing.  Attributes MAY be asserted by CSPs to RPs in support of pseudonymous identity with verified attributes.
 
 **IAL 3**:
-At Identity Assurance Level 3, in-person identity proofing is required. Identifying attributes must be verified by an authorized and trained representative of the CSP. As with IAL 2, attributes MAY be asserted by CSPs to RPs in support of pseudonymous identity with verified attributes. 
+At Identity Assurance Level 3, in-person identity proofing is required. Identifying attributes must be verified by an authorized and trained representative of the CSP. As with IAL 2, attributes MAY be asserted by CSPs to RPs in support of pseudonymous identity with verified attributes.
+
+<div class="breaker">
 
 ## Table of Contents
+
+</div>
 
 [1. Purpose](#sec1)
 
@@ -223,5 +234,3 @@ At Identity Assurance Level 3, in-person identity proofing is required. Identify
 [9. Usability Considerations](#sec9)
 
 [10. References](#references)
-
- 

--- a/sp800-63a/cover.md
+++ b/sp800-63a/cover.md
@@ -186,7 +186,7 @@ The terms “CAN” and “CANNOT” indicate a possibility and capability, whet
 
 </div>
 
-<div class="breaker">
+<div class="breaker" markdown="1">
 
 ## Executive Summary
 
@@ -208,7 +208,7 @@ At IAL 2, the claimed identity is proven with evidence that supports the real wo
 **IAL 3**:
 At Identity Assurance Level 3, in-person identity proofing is required. Identifying attributes must be verified by an authorized and trained representative of the CSP. As with IAL 2, attributes MAY be asserted by CSPs to RPs in support of pseudonymous identity with verified attributes.
 
-<div class="breaker">
+<div class="breaker" markdown="1">
 
 ## Table of Contents
 

--- a/sp800-63a/sec10_references.md
+++ b/sp800-63a/sec10_references.md
@@ -15,6 +15,6 @@
 <a name="fbcacp"></a>[FBCACP] X.509 Certificate Policy
 For The Federal Bridge Certification Authority (FBCA), Version 2.27 (December 2, 2013), available at: <https://www.idmanagement.gov/IDM/servlet/fileField?entityId=ka0t0000000TN7cAAG&field=File__Body__s>.
 
-<a name="fbcasup"></a>[FBCASUP] FBCA Supplementary Antecedent, In-Person Definition (July 16, 2009), available at: https://www.idmanagement.gov/IDM/servlet/fileField?entityId=ka0t0000000TNPgAAO&field=File__Body__s.
+<a name="fbcasup"></a>[FBCASUP] FBCA Supplementary Antecedent, In-Person Definition (July 16, 2009), available at: <https://www.idmanagement.gov/IDM/servlet/fileField?entityId=ka0t0000000TNPgAAO&field=File__Body__s>.
 
-<a name-"A-130"></a>[A-130] OMB Circular A-130, *Managing Federal Information as a Strategic Resource* (July 28, 2016), available at: <https://www.whitehouse.gov/omb/circulars_default>
+<a name="A-130"></a>[A-130] OMB Circular A-130, *Managing Federal Information as a Strategic Resource* (July 28, 2016), available at: <https://www.whitehouse.gov/omb/circulars_default>

--- a/sp800-63a/sec4_ial.md
+++ b/sp800-63a/sec4_ial.md
@@ -28,7 +28,7 @@ It is permissible for the CSP to collect additional information in the process o
 
 ## 4.2. General Requirements
 
-[Table 4-1](#63aSec4-Table1) lists strict adherence to M-04-04 Level of Assurance, mapping the corresponding Identity Assurance Levels. 
+[Table 4-1](#63aSec4-Table1) lists strict adherence to M-04-04 Level of Assurance, mapping the corresponding Identity Assurance Levels.
 
 
 <a name="63aSec4-Table1"></a>
@@ -41,12 +41,12 @@ It is permissible for the CSP to collect additional information in the process o
 
 | M-04-04 Level of Assurance (LOA) | Identity Assurance Level (IAL)|
 |:------------------:|:-----------------------------:|
-| 1 | 1 | 
+| 1 | 1 |
 | 2 | 2 |
 | 3 | 2 |
 | 4 | 3 |
 
-However, [Table 4-2](#63aSec4-Table2) shows the expanded set of IALs that are allowable to meet M-04-04 Levels of Assurance. Agencies SHALL select the corresponding IAL based on the assessed M-04-04 LOA. Agencies SHOULD consider the privacy risks of stronger identity proofing and SHOULD NOT select an IAL that is higher than necessary considering the sensitivity of the business purpose. 
+However, [Table 4-2](#63aSec4-Table2) shows the expanded set of IALs that are allowable to meet M-04-04 Levels of Assurance. Agencies SHALL select the corresponding IAL based on the assessed M-04-04 LOA. Agencies SHOULD consider the privacy risks of stronger identity proofing and SHOULD NOT select an IAL that is higher than necessary considering the sensitivity of the business purpose.
 
 <a name="63aSec4-Table2"></a>
 
@@ -54,30 +54,30 @@ However, [Table 4-2](#63aSec4-Table2) shows the expanded set of IALs that are al
 
 **Table 4-2.  Recommended M-04-04 IAL Requirements**
 
-</div> 
+</div>
 
 | M-04-04 Level of Assurance | Identity Assurance Level
 |:------------------:|:-----------------------------:
-| 1 | 1 
-| 2 | 1 or 2 
-| 3 | 1 or 2 
-| 4 | 1, 2 or 3 
+| 1 | 1
+| 2 | 1 or 2
+| 3 | 1 or 2
+| 4 | 1, 2 or 3
 
 
-The following requirements apply to any CSP performing identity proofing at IAL 2 or 3. 
+The following requirements apply to any CSP performing identity proofing at IAL 2 or 3.
 
 1. Identity proofing SHALL NOT be performed to determine suitability/entitlement to gain access to services or benefits.
 2. The CSP SHOULD NOT collect the SSN unless it is necessary for performing identity resolution and cannot be accomplished by collection of another attribute or combination of attributes.
-2. Collection of personally identifiable information (PII) SHALL be limited to the minimum necessary to validate the existence of the claimed identity and associate the claimed identity to the applicant providing identity evidence based on best available practices for appropriate identity resolution, validation, and verification. 
-3. The CSP SHALL provide explicit notice at the time of collection to the applicant regarding the purpose for collecting and maintaining a record of the attributes necessary for identity proofing, including whether the such attributes are voluntary or mandatory in order to complete the identity proofing transactions and the consequences for not providing the attributes. 
-5.	 The CSP SHALL NOT use attributes collected and maintained in the identity proofing process for any purpose other than identity proofing, authentication, authorization or attribute assertions, or to comply with law or legal process unless the CSP provides clear notice and obtains consent from the subscriber for additional uses. CSPs SHALL NOT make consent a condition of the service. 
-6.	The CSP SHALL provide effective mechanisms for redress of applicant complaints or problems arising from the identity proofing. These mechanisms SHALL be easy for applicants to find and access. 
+2. Collection of personally identifiable information (PII) SHALL be limited to the minimum necessary to validate the existence of the claimed identity and associate the claimed identity to the applicant providing identity evidence based on best available practices for appropriate identity resolution, validation, and verification.
+3. The CSP SHALL provide explicit notice at the time of collection to the applicant regarding the purpose for collecting and maintaining a record of the attributes necessary for identity proofing, including whether the such attributes are voluntary or mandatory in order to complete the identity proofing transactions and the consequences for not providing the attributes.
+5.	 The CSP SHALL NOT use attributes collected and maintained in the identity proofing process for any purpose other than identity proofing, authentication, authorization or attribute assertions, or to comply with law or legal process unless the CSP provides clear notice and obtains consent from the subscriber for additional uses. CSPs SHALL NOT make consent a condition of the service.
+6.	The CSP SHALL provide effective mechanisms for redress of applicant complaints or problems arising from the identity proofing. These mechanisms SHALL be easy for applicants to find and access.
 7. The identity proofing and enrollment processes SHALL be performed according to an applicable written policy or *practice statement* that specifies the particular steps taken to verify identities.
 3. The CSP SHALL maintain a record of all steps taken to verify the identity of the applicant and SHALL record the types of identity evidence presented in the proofing process. The CSP SHALL conduct a privacy risk assessment to determine:
 
 	a) Any steps that it will take to verify the identity of the applicant beyond any mandatory requirements specified herein;
 
-	b) the PII, including any biometrics, images, scans, or other copies of the identity evidence that the CSP will maintain as a record of identity proofing. Note: Specific federal requirements may apply; and 
+	b) the PII, including any biometrics, images, scans, or other copies of the identity evidence that the CSP will maintain as a record of identity proofing. Note: Specific federal requirements may apply; and
 
 	c) the schedule of retention for these records. Note: Specific National Archives and Records Administration (NARA) records retention schedules may apply.  
 
@@ -88,13 +88,13 @@ The following requirements apply to any CSP performing identity proofing at IAL 
 12. In the event a CSP ceases to conduct identity proofing and enrollment processes, the CSP SHALL be responsible for fully disposing of or destroying any sensitive data including PII, or its protection from unauthorized access for the duration of retention.
 13. Regardless of whether the CSP is an agency or private sector provider, the following requirements apply to the agency offering or using the proofing service:
 
- 
+
  a) The agency SHALL consult with their Senior Agency Official for Privacy to conduct an analysis to determine whether the collection of PII to conduct identity proofing triggers the requirements of the Privacy Act.
- 
+
  b) The agency SHALL publish a System of Records Notice to cover such collections, as applicable.
- 
+
  c) The agency SHALL consult with their Senior Agency Official for Privacy to conduct an analysis to determine whether the collection of PII to conduct identity proofing triggers the requirements of the E-Government Act of 2002.
- 
+
  d) The agency SHALL publish a Privacy Impact Assessment to cover such collections, as applicable.
 
 ## 4.4. Identity Assurance Level 1
@@ -105,7 +105,7 @@ The CSP SHALL NOT proof applicants.  Applicants MAY self-assert zero or more att
 
 IAL 2 allows for remote or in-person identity proofing.  IAL supports a wide range of acceptable identity proofing techniques in order to increase user adoption, decrease false negatives (legitimate applicants that cannot successfully complete identity proofing), and detect to the best extent possible the presentation of fraudulent identities by a malicious applicant. A CSP MAY exceed these requirements.
 
-A CSP SHOULD implement identity proofing in accordance with [Section 4.5.1](#normal). Depending on the population the CSP serves, the CSP MAY implement identity proofing in accordance with [Section 4.5.2](#antecedent) or [Section 4.5.3](#referee). 
+A CSP SHOULD implement identity proofing in accordance with [Section 4.5.1](#normal). Depending on the population the CSP serves, the CSP MAY implement identity proofing in accordance with [Section 4.5.2](#antecedent) or [Section 4.5.3](#referee).
 
 ### <a name="normal"></a>4.5.1. IAL2 Conventional Proofing Requirements
 
@@ -145,13 +145,13 @@ The CSP SHOULD perform identity proofing in-person. The CSP MAY perform remote i
 
 - **If CSP performed in-person proofing:**  
 
-	- The CSP SHALL send a notification of proofing to the confirmed address of record. 
+	- The CSP SHALL send a notification of proofing to the confirmed address of record.
 	- The CSP MAY provide an enrollment code directly to the subscriber if binding to an authenticator will occur at a later time.
-	- The enrollment code SHALL be valid for a maximum of 7 days 
+	- The enrollment code SHALL be valid for a maximum of 7 days
 
 - **If the CSP performed remote proofing:**  
 	- A CSP SHALL send an enrollment code to an address of record of the applicant.
-	- The applicant SHALL present a valid enrollment code to complete the identity proofing process.	
+	- The applicant SHALL present a valid enrollment code to complete the identity proofing process.
 	- The CSP SHOULD send the enrollment code to the physical mailing address that has been verified in records.  The CSP MAY send the enrollment code to a mobile telephone (SMS or voice), landline telephone, or email that has been verified in records.
 	- If the enrollment code is also intended to be an authentication factor, it SHALL be reset upon first use.
 	- Enrollment codes sent by means other than physical mail SHALL be valid for a maximum of 10 minutes; those sent to a postal address of record SHALL be valid for a maximum of 7 days but MAY be made valid up to 21 days via an exception process to accommodate addresses outside the direct reach of the U.S. postal service.  
@@ -177,7 +177,7 @@ In instances where the individual enrolling cannot meet the identity evidence re
 
 IAL 3 adds additional rigor to the steps required at IAL 2, to include providing further evidence of superior strength, and is subjected to additional and specific processes, including the use of biometrics, to further protect the identity and RP from impersonation, fraud, or other significantly harmful damages.  In addition, identity proofing at IAL 3 is performed in-person. See [Section 5.3.3](#vip) for more details. A CSP MAY exceed these requirements.
 
-### 4.6.2. Resolution Requirements
+### 4.6.1. Resolution Requirements
 
 Collection of PII SHALL be limited to the minimum necessary to resolve to a unique identity record.  See [Section 5.1](#resolve) for general resolution requirements.
 
@@ -213,11 +213,11 @@ Remote proofing SHALL NOT be allowed.
 
 - The CSP SHALL confirm address of record through validation of the address contained on any supplied, valid piece of identity evidence.
 - Self-asserted address data SHALL NOT be used for confirmation.
-- A notification of proofing SHALL be sent to the confirmed address of record. 
+- A notification of proofing SHALL be sent to the confirmed address of record.
 
 ### 4.6.7. Biometric Collection
 
-The CSP SHALL collect and record a biometric sample at the time of proofing (e.g., facial image or fingerprints) the purposes of non-repudiation and re-proofing.  See [Section 5.2.3](#biometric_use) of SP 800-63B for more detail on biometric collection. 
+The CSP SHALL collect and record a biometric sample at the time of proofing (e.g., facial image or fingerprints) the purposes of non-repudiation and re-proofing.  See [Section 5.2.3](#biometric_use) of SP 800-63B for more detail on biometric collection.
 
 ### 4.6.8. Security  Controls
 
@@ -228,7 +228,7 @@ An enrollment code allows the CSP to confirm that the applicant controls an addr
 
 An enrollment code SHALL be comprised of one of the following:
 
-* Minimually, a random six (6) character alphanumeric. 
+* Minimually, a random six (6) character alphanumeric.
 * A machine readable optical label, such as a QR Code, that contains data of similar or higher entropy as a random six (6) character alphanumeric.
 
 
@@ -243,7 +243,7 @@ An enrollment code SHALL be comprised of one of the following:
 
 **Table 4-3.  IAL Requirements Summary**
 
-</div> 
+</div>
 
 Requirement | IAL 1 | IAL 2 | IAL 3
 ------------|-------|-------|-------
@@ -255,5 +255,3 @@ Verification| No verification of identity is required |- At a minimum, the appli
 Address Confirmation|No requirements for address confirmation|- Self-asserted address data SHALL NOT be used for confirmation.<br>- An enrollment code consisting of at least 6 random digits SHALL be included in address confirmation.<br>- May be sent to a mobile telephone (SMS or voice), landline telephone, email, or physical mailing address obtained from records.<br>- If the enrollment code is also intended to be an authentication factor, it SHALL be reset upon first use.<br>- Enrollment codes sent by means other than physical mail SHALL be valid for a maximum of 10 minutes; those sent to a postal address of record SHALL be valid for a maximum of 7 days but MAY be made valid up to 21 days via an exception process to accommodate addresses outside the direct reach of the U.S. postal service.  <br> - A notification of proofing SHALL be sent via a different address of record than the destination of the enrollment code|- The CSP SHALL confirm address of record through validation of the address contained on any supplied, valid piece of identity evidence. - Self-asserted address data SHALL NOT be used for confirmation. - A notification of proofing SHALL be sent to the confirmed address of record.
 Biometric Collection|No|Yes|Yes|
 Security Controls|N/A|[[SP 800-53]](#SP800-53) Moderate Baseline (or equivalent)|[[SP 800-53]](#SP800-53) High Baseline (or equivalent)
-
-

--- a/static/css/NISTPages.css
+++ b/static/css/NISTPages.css
@@ -102,7 +102,7 @@ ul.audiences li {
   width: 139px;
 }
 
-.navbar-fixed-left + .container {
+.container {
   padding-left: 160px;
 }
 
@@ -149,5 +149,3 @@ table>tbody+tbody{
 table table{
   background-color:#fff
 }
-
-

--- a/static/css/NISTPages.css
+++ b/static/css/NISTPages.css
@@ -130,16 +130,16 @@ table>thead>tr>th,table>tbody>tr>th,table>tfoot>tr>th,table>thead>tr>td,table>tb
   padding:8px;
   line-height:1.42857143;
   vertical-align:top;
-  border-top:1px solid #ddd
+  border:1px solid #ddd
 }
 
 table>thead>tr>th{
   vertical-align:bottom;
-  border-bottom:2px solid #ddd
+  border-bottom:2px solid #ddd;
 }
 
 table>caption+thead>tr:first-child>th,table>colgroup+thead>tr:first-child>th,table>thead:first-child>tr:first-child>th,table>caption+thead>tr:first-child>td,table>colgroup+thead>tr:first-child>td,table>thead:first-child>tr:first-child>td{
-  border-top:0
+  border-top:1px solid #ddd;
 }
 
 table>tbody+tbody{

--- a/static/css/NISTStyle.css
+++ b/static/css/NISTStyle.css
@@ -198,11 +198,6 @@ td,th{
 		box-shadow:none !important
 	}
 
-	#sidebar {
-		display: none;
-		width: 0px;
-	}
-
 	.nist-header {
 		display: none;
 	}
@@ -264,7 +259,8 @@ td,th{
 	}
 
 	.navbar{
-		display:none
+		display:none;
+		width: 0px;
 	}
 
 	.table td,.table th{

--- a/static/css/NISTStyle.css
+++ b/static/css/NISTStyle.css
@@ -198,6 +198,24 @@ td,th{
 		box-shadow:none !important
 	}
 
+	#sidebar {
+		display: none;
+		width: 0px;
+	}
+
+	.nist-header {
+		display: none;
+	}
+
+	div.container {
+		padding-left:30px;
+		padding-right:30px;
+	}
+
+	.breaker{
+		page-break-before: always;
+	}
+
 	a,a:visited{
 		text-decoration:underline
 		color: purple;
@@ -6873,7 +6891,7 @@ table.GBInnerDataTable th{
 	text-align:center;
 	font-size:18px;
 	color:#555;
-	margin:15px 
+	margin:15px
 }
 
 #dropZone.hover{


### PR DESCRIPTION
Updates to CSS files to facilitate the desired print layout by eliminating the header, left nav bar, and associated padding. Updates to MD files were only performed within the 63A files as a demonstration of implementation.

Also fixed a few errant line breaks within some markdown files and re-numbered a section heading.

Updates to CSS files to give all tables across this repo borders

Note: It appears that my editor (Atom) removed some spaces from the end of some lines making it appear that there were more content changes than actually performed. 