### PR TITLE
Remove "DRAFT" from title/description of final docs

### DIFF
--- a/sp800-63-3.md
+++ b/sp800-63-3.md
@@ -1,7 +1,7 @@
 ---
 layout: page
-title: "DRAFT NIST Special Publication 800-63-3"
-description: "DRAFT NIST Special Publication 800-63-3"
+title: "NIST Special Publication 800-63-3"
+description: "NIST Special Publication 800-63-3"
 ---
 
 {{ site.time | date_to_rfc822 }}

--- a/sp800-63a.md
+++ b/sp800-63a.md
@@ -1,7 +1,7 @@
 ---
 layout: page
-title: "DRAFT NIST Special Publication 800-63A"
-description: "DRAFT NIST Special Publication 800-63A"
+title: "NIST Special Publication 800-63A"
+description: "NIST Special Publication 800-63A"
 ---
 
 {{ site.time | date_to_rfc822 }}

--- a/sp800-63b.md
+++ b/sp800-63b.md
@@ -1,7 +1,7 @@
 ---
 layout: page
-title: "DRAFT NIST Special Publication 800-63B"
-description: "DRAFT NIST Special Publication 800-63B"
+title: "NIST Special Publication 800-63B"
+description: "NIST Special Publication 800-63B"
 ---
 
 {{ site.time | date_to_rfc822 }}

--- a/sp800-63c.md
+++ b/sp800-63c.md
@@ -1,7 +1,7 @@
 ---
 layout: page
-title: "DRAFT NIST Special Publication 800-63C"
-description: "DRAFT NIST Special Publication 800-63C"
+title: "NIST Special Publication 800-63C"
+description: "NIST Special Publication 800-63C"
 ---
 
 {{ site.time | date_to_rfc822 }}


### PR DESCRIPTION
Congrats on finalizing the publication! I noticed that the `<title>` tag was still showing `DRAFT` in my browser tab when visiting https://pages.nist.gov/800-63-3/sp800-63-3.html, so this removes the `DRAFT` notation from all 4 main docs.

Screenshot of browser tab right now at https://pages.nist.gov/800-63-3/sp800-63b.html:

<img width="282" alt="screen shot 2017-06-23 at 10 37 35 am" src="https://user-images.githubusercontent.com/4592/27493787-fb447a46-57ff-11e7-83f9-cab6f8acb026.png">
