### PR TITLE
VoT guidance

### DIFF
--- a/sp800-63d/vot_mapping.md
+++ b/sp800-63d/vot_mapping.md
@@ -5,7 +5,7 @@
 ## Mapping SP 800-63 to Vectors of Trust
 _This section is normative._
 
-Vectors of Trust (VoT) [[VoT]](https://tools.ietf.org/html/draft-richer-vectors-of-trust-05) is a standard for expressing information about an authentication transaction from an IdP to an RP. This information is split into several orthogonal component categories, similar to the way that the assurance levels defined in SP 800-63 are split into different xAL categories.
+Vectors of Trust (VoT) [[VoT]](https://tools.ietf.org/html/draft-richer-vectors-of-trust-07) is a standard for expressing information about an authentication transaction from an IdP to an RP. This information is split into several orthogonal component categories, similar to the way that the assurance levels defined in SP 800-63 are split into different xAL categories.
 
 This document uses terms as defined in [SP 800-63-3 Appendix A](sp800-63-3.html#def-and-acr). Some definitions differ from those in VoT. Notably, the term "authenticator" herein has the same meaning as "credential" in VoT.
 
@@ -17,13 +17,13 @@ The trustmark URI for these definitions is [[ URI for this document ]].
 
 This document uses the four components defined in VoT: Identity Proofing (P), Primary Credential Usage (C), Primary Credential Management (M), and Assertion Presentation (A). This document does not define any additional component categories.
 
-The VoT [component P](https://tools.ietf.org/html/draft-richer-vectors-of-trust-05#section-2.1) corresponds to identity proofing requirements and recommendations found in [SP 800-63A](sp800-63a.html). As such, the document maps SP 800-63's Identity Assurance Level (IAL) and identity proofing characteristics into VoT's P.
+The VoT [component P](https://tools.ietf.org/html/draft-richer-vectors-of-trust-07#section-2.1) corresponds to identity proofing requirements and recommendations found in [SP 800-63A](sp800-63a.html). As such, the document maps SP 800-63's Identity Assurance Level (IAL) and identity proofing characteristics into VoT's P.
 
-The VoT [component C](https://tools.ietf.org/html/draft-richer-vectors-of-trust-05#section-2.2) corresponds to authentication requirements and recommendations found in [SP 800-63B](sp800-63b.html). As such, this document maps SP 800-63's Authenticator Assurance Level (AAL), authenticator types, and authentication characteristics into VoT's C.
+The VoT [component C](https://tools.ietf.org/html/draft-richer-vectors-of-trust-07#section-2.2) corresponds to authentication requirements and recommendations found in [SP 800-63B](sp800-63b.html). As such, this document maps SP 800-63's Authenticator Assurance Level (AAL), authenticator types, and authentication characteristics into VoT's C.
 
-The VoT [component M](https://tools.ietf.org/html/draft-richer-vectors-of-trust-05#section-2.3) corresponds to authenticator lifecycle management requirements and recommendations found in [SP 800-63B Section 6](sp800-63b.html#sec6). As such, this document maps SP 800-63's authenticator lifecycle management characteristics into VoT's M.
+The VoT [component M](https://tools.ietf.org/html/draft-richer-vectors-of-trust-07#section-2.3) corresponds to authenticator lifecycle management requirements and recommendations found in [SP 800-63B Section 6](sp800-63b.html#sec6). As such, this document maps SP 800-63's authenticator lifecycle management characteristics into VoT's M.
 
-The VoT [component A](https://tools.ietf.org/html/draft-richer-vectors-of-trust-05#section-2.4) corresponds to federation requirements and recommendations found in [SP 800-63C](sp800-63c.html). As such, this document maps SP 800-63's Federation Assurance Level (FAL) and assertion presentation into VoT's A.
+The VoT [component A](https://tools.ietf.org/html/draft-richer-vectors-of-trust-07#section-2.4) corresponds to federation requirements and recommendations found in [SP 800-63C](sp800-63c.html). As such, this document maps SP 800-63's Federation Assurance Level (FAL) and assertion presentation into VoT's A.
 
 **Table: 800-63 General Mapping to VoT Components**
 
@@ -36,7 +36,7 @@ The VoT [component A](https://tools.ietf.org/html/draft-richer-vectors-of-trust-
 
 ## Component Values
 
-This document defines new component values in accordance with [VoT Section 2](https://tools.ietf.org/html/draft-richer-vectors-of-trust-05#section-2).
+This document defines new component values in accordance with [VoT Section 2](https://tools.ietf.org/html/draft-richer-vectors-of-trust-07#section-2).
 
 The component values for IAL, AAL, and FAL are expressed with numeric identifiers. Only one numeric identifier SHALL be used for each xAL. The implemented IAL, AAL, and/or FAL SHALL be indicated in the vector. Other digital identity information (i.e., identity proofing characteristics, authenticator type(s) used, authentication characteristics, authenticator lifecycle management characteristics, and assertion presentation values) are expressed with alphabetic identifiers. Multiple alphabetic identifiers MAY be used simultaneously. Some alphabetically-expressed values SHALL be indicated in the vector if implementation matches the uses described in the following sections; otherwise, these values MAY be indicated in the vector.
 
@@ -176,8 +176,6 @@ If the authenticator(s) is/are bound/issued:
 
 If the subscriber's account had only one authentication factor bound to it at account creation, and an additional authenticator of a different authentication factor is added after account creation, Ms SHALL be indicated in the vector.
 
-**NOTE: I don't think the phrasing is quite right on adding a second factor yet.**
-
 If the following conditions are met, Ma SHALL be indicated in the vector.
 
 * The subscriber has been identity proofed at IAL2 or IAL3.
@@ -212,8 +210,6 @@ If a back-channel presentation mechanism is used, Ab SHOULD be indicated in the 
 ### Summary
 
 The table below describes the values that are required to be indicated when implementation matches the uses described in the above "Use" sections to conform to this publication.
-
-**NOTE: This table gives me a headache. If we do choose to include it, or a better version of it, in the draft, do we want to add column for encouraged values "SHOULDs"? Or are there any ideas for better ways to organize this table?**
 
 |Component Value|Indication in Vector Required*|
 |:----:|:--:|
@@ -260,4 +256,4 @@ The table below describes the values that are required to be indicated when impl
 
 ## References
 
-[VoT] Vectors of Trust, April 3, 2017, available at: [https://tools.ietf.org/html/draft-richer-vectors-of-trust-05](https://tools.ietf.org/html/draft-richer-vectors-of-trust-05)
+[VoT] Vectors of Trust, December 8, 2018, available at: [https://tools.ietf.org/html/draft-richer-vectors-of-trust-07](https://tools.ietf.org/html/draft-richer-vectors-of-trust-07)

--- a/sp800-63d/vot_mapping.md
+++ b/sp800-63d/vot_mapping.md
@@ -15,21 +15,19 @@ The trustmark URI for these definitions is [[ URI for this document ]].
 
 This document uses the four components defined in VoT: Identity Proofing (P), Primary Credential Usage (C), Primary Credential Management (M), and Assertion Presentation (A).
 
-The VoT components P, C, and A correspond to 800-63's Identity Assurance Level (IAL), Authenticator Assurance Level (AAL), and Federation Assurance Level (FAL), respectively. While M does not correspond directly to an 800-63 assurance level category, this document defines a set of M values derived from requirements and recommendations in 800-63. 
+The VoT components P, C, and A correspond to 800-63's Identity Assurance Level (IAL), Authenticator Assurance Level (AAL), and Federation Assurance Level (FAL), respectively. While M does not correspond directly to an 800-63 assurance level category, this document defines a set of M values derived from requirements and recommendations in 800-63. This document does not define any additional component categories.
 
-This document uses terms as defined in 800-63-3. Some definitions differ from those in VoT. Notably, the term "authenticator" herein has the same meaning as "credential" in VoT.
-
-This document does not define any additional component categories. Any additional categories SHALL NOT be used.
+This document uses terms as defined in 800-63-3, Appendix A - Definitions and Abbreviations. Some definitions differ from those in VoT. Notably, the term "authenticator" herein has the same meaning as "credential" in VoT.
 
 ## Component Values
 
-This document does not use any of the existing values in VoT but instead defines new component values in accordance with Section 8 of VoT.
+This document defines new component values in accordance with Section 8 of VoT.
 
 ### Identity Proofing
 
-#### IAL to VoT
+IAL maps into the VoT component P using a numeric identifier. Identity proofing characteristics map into P using an alphabetic identifier.
 
-IAL maps into the VoT component P using a numeric identifier. The implemented IAL component value SHALL be asserted. Only one numeric identifier SHALL be used. 
+#### IAL to VoT
 
 |IAL|Component Value|
 |:----:|:--:|
@@ -40,9 +38,7 @@ IAL maps into the VoT component P using a numeric identifier. The implemented IA
 
 #### Identity Proofing Characteristics
 
-In addition, identity proofing characteristics MAY be indicated using an alphabetic identifier. Multiple alphabetic identifiers MAY be used simultaneously. Identity proofing methods or approaches that are required for the asserted IAL SHOULD NOT be asserted. The proofing method SHALL be sufficient or greater than that which is required by the IAL value indicated in the vector. 
-
-|Identity Proofing Method or Approach|Component Value|
+|Identity Proofing Characteristic|Component Value|
 |:----:|:--:|
 |In-person|Pi|
 |Remote|Pr|
@@ -50,16 +46,15 @@ In addition, identity proofing characteristics MAY be indicated using an alphabe
 |Address Confirmation with Postal Address|Pa|
 |Trusted Referee|Pt|
 |Additional features implemented beyond requirements for asserted IAL|Px|
+|**NOTE: We don't think Px conveys very much - because which values represent "approaches beyond those required under the asserted IAL"? Suggest removing this value. Does this comment also apply to Ax for federation?**||
 
 >Note: Any credential service provider performing identity proofing at IAL2 or IAL3 MUST conduct a privacy risk assessment. Trusted referee policy and procedures MUST be documented per SP 800-63A Section 5.3.4.
 
-Any discrepancies in the assessed and implemented assurance level SHOULD be documented in a digital identity acceptance statement, per SP 800-63-3 Section 5.5.
-
 ### Authenticator Usage
 
-#### AAL to VoT
+AAL maps into the VoT component C using a numeric identifier. Authenticator types and characteristics map into C using an alphabetic identifier.
 
-AAL maps into the VoT component C using a numeric identifier. The implemented AAL component value SHALL be asserted. Only one numeric identifier SHALL be used. 
+#### AAL to VoT
 
 |AAL|Component Value|
 |:----:|:--:|
@@ -68,8 +63,6 @@ AAL maps into the VoT component C using a numeric identifier. The implemented AA
 |AAL3|C3|
 
 #### Authenticator Types
-
-The authenticator type(s) used MAY be indicated using an alphabetic identifier. Multiple aphabetic identifiers MAY be used simultaneously. The authenticator type(s) SHALL be sufficient or greater than that which is required by the AAL value indicated in the vector.
 
 |Authenticator Type|Component Value|
 |:----:|:--:|
@@ -86,9 +79,7 @@ The authenticator type(s) used MAY be indicated using an alphabetic identifier. 
 
 #### Authentication Characteristics
 
-The authentication characteristics MAY be indicated using an alphabetic identifier. Multiple alphabetic identifiers MAY be used simultaneously. The authenticator characteristics SHALL be sufficient or greater than that which is required by the AAL value indicated in the vector.
-
-|Authentication Feature|Component Value|
+|Authentication Characteristic|Component Value|
 |:----:|:--:|
 |FIPS 140 Validation|Ci|
 |Man-in-the-middle Attack Resistance|Cm|
@@ -101,14 +92,23 @@ The authentication characteristics MAY be indicated using an alphabetic identifi
 
 >Note: Some authentication approaches described in Table XX are not applicable for all three AALs.
 
-Any discrepancy in the assessed and implemented assurance level SHOULD be documented in a digital identity acceptance statement, per SP 800-63-3 Section 5.5.
+### Authenticator Lifecycle Management to VoT
 
+Authenticator lifecyle management characteristics, per 800-63B Section 6, map into the VoT component M using an alphabetic identifier.
 
-### Assertion Presentation
+|Authenticator Lifecycle Management Characteristic|Component Value|
+|:----:|:--:|
+|Authenticator issued/bound during proofing session|Mp|
+|Authenticator issued/bound after proofing session (remote)|Mr|
+|Authenticator issued/bound after proofing session (in-person)|Mi|
+|Second factor bound to a single-factor account|Ms|
+|Authentication factors reestablished (account recovery) using abbreviated proofing process|Ma|
+
+### Federation and Assertions
+
+FAL maps into the VoT component A using a numeric identifier. Assertion presentation maps into A using an alphabetic identifier.
 
 #### FAL to VoT
-
-FAL maps into the VoT component A using a numeric identifier. Only one numeric identifier SHALL be used.
 
 |FAL|Component Value|
 |:----:|:--:|
@@ -118,25 +118,87 @@ FAL maps into the VoT component A using a numeric identifier. Only one numeric i
 
 #### Assertion Presentation
 
-In addition, the presentation mechanism MAY be indicated using an alphabetic identifier. Multiple aphabetic identifiers MAY be used simultaneously. The presentation mechanism SHALL be sufficient or greater than that which is required by the FAL value indicated in the vector.
-
 |Presentation|Component Value|
 |:----:|:--:|
 |Front channel|Af|
 |Back channel|Ab|
 |Additional features implemented beyond requirements for asserted FAL|Ax|
 
-Any discrepancy in the assessed and implemented assurance level SHOULD be documented in a digital identity acceptance statement, per SP 800-63-3 Section 5.5.
+## How to Use the Values in Vectors
 
-### Authenticator Management to VoT
+The implemented IAL, AAL, and/or FAL component value(s) SHALL be indicated in the vector. Only one numeric identifier SHALL be used for each xAL. Any discrepancies in the assessed and implemented assurance level SHOULD be documented in a digital identity acceptance statement, per SP 800-63-3 Section 5.5.
 
-Authenticator lifecyle management, per 800-63B Section 6, maps into the VoT component M using an alphabetic identifier. Authenticator management method MAY be indicated using an alphabetic identifier. Multiple alphabetic identifiers MAY be used simultaneously.
+Identity proofing characteristics, authenticator type(s) used, authentication characteristics, authenticator lifecycle management characteristics, and assertion presentation values MAY be indicated in the vector. Per the requirements in the following sections, some of these values SHALL be indicated in the vector depending on the approaches implemented. Multiple alphabetic identifiers MAY be used simultaneously. 
 
-|Credential Management Method|Component Value|
-|:----:|:--:|
-|Credential issued/bound during proofing session|Mp|
-|Credential issued/bound after proofing session (remote)|Mr|
-|Credential issued/bound after proofing session (in-person)|Mi|
-|Second factor bound to a single-factor account|Ms|
-|Authentication factors reestablished (account recovery) using full proofing process|Ma|
-|Authentication factors reestablished (account recovery) using abbreviated proofing process|Mb|
+Identity proofing characteristics, authenticator type(s) used, authentication characteristics, and assertion presentation values SHOULD be indicated only when they demonstrate the implementation of approaches beyond those required by the xAL indicated in the vector. The appropriate value that signifies this (i.e., Px, Cx, and Ax) SHOULD also be indicated. Values SHOULD NOT be indicated that represent approaches already required by the xAL indicated in the vector. These approaches are assumed to be implemented per the xAL's requirements. 
+
+**Example:** C2.Cx.Cv could be asserted if implementing AAL2 and an authenticator is used that provides verifier impersonation resistance, since verifier impersonation resistance is not required under AAL2.
+
+Any additional component categories SHALL NOT be used.
+
+### Identity Proofing Characteristics
+
+If implementing IAL2 and KBV is used for identity verification, Pk SHALL be indicated in the vector (e.g., P2.Pk).
+
+If using a trusted referee acting on behalf of the applicant in the identity proofing process, Pt SHALL be indicated in the vector.
+
+If the subscriber is identity proofed in-person, Pi SHOULD be indicated in the vector.
+
+If the subscriber is identity proofed remotely, Pr SHOULD be indicated in the vector.
+
+If confirming an applicant's address by sending an enrollment code to a postal address, Pa SHOULD be indicated in the vector.
+
+### Authenticator Types
+
+The authenticator type(s) used SHALL be indicated in the vector with the following exceptions.
+
+If implementing AAL3 and authentication is achieved using one of the following two options, the authenticator types used MAY NOT be indicated in the vector.
+
+* Multi-Factor Cryptographic Device; OR
+* Single-Factor Cryptographic Device used in conjunction with Memorized Secret
+
+If the user authenticates using a restricted authenticator, Cr and the value representing the authenticator used SHALL be indicated in the vector.
+
+**Example:** Cr.Co would be asserted if the user authenticates using a secret sent via SMS to an out-of-band device.
+
+### Authentication Characteristics
+
+If implementing AAL1 or AAL2, and:
+
+* the user authenticates with an authenticator that provides verifier impersonation resistance, Cv SHOULD be indicated in the vector.
+* the user authenticates with an authenticator that provides verifier compromise resistance, Cs SHOULD be indicated in the vector.
+* authentication intent from at least one authenticator is demonstrated, Cn SHOULD be indicated in the vector.
+* for non-government agency authenticators and verifiers, authenticator(s) or verifier(s) are validated to meet the requirements of FIPS 140 Level 1, Ci SHOULD be indicated in the vector.
+
+If using a biometric for authentication, and:
+
+* biometric comparison is performed centrally (not locally on the claimant's device), Ck SHALL be indicated in the vector.
+* the biometric system implements PAD, Ck SHOULD be indicated in the vector.
+
+**NOTE: Should we add a vector value for FMR?**
+
+MitM attack resistance
+
+**NOTE: I'm struggling to find the case where a MitM resistance value is interesting - it seems to be required most of the time and would be redundant with the xAL indicated in the vector.**
+
+### Authenticator Lifecycle Management
+
+If the authenticator(s) is/are bound/issued:
+
+* during a single proofing session, Mp SHALL be indicated in the vector.
+* remotely after the proofing session, Mr SHALL be indicated in the vector.
+* in-person after the proofing session, Mi SHALL be indicated in the vector.
+
+If the subscriber's account had only one authentication factor bound to it at account creation, and an additional authenticator of a different authentication factor is added after account creation, Ms SHALL be indicated in the vector.
+
+**NOTE: I don't think the phrasing is quite right on adding a second factor yet.**
+
+If a subscriber loses all authentictors of a factor necessary to complete multi-factor authentication, has been identity proofed at IAL2 or IAL3, and consequently undergoes an abbreviated identity proofing process to reestablish authentication factors, Ma SHALL be indicated in the vector.
+
+### Assertion Presentation
+
+If a front-channel presentation mechanism is used, Af SHOULD be indicated in the vector.
+
+If a back-channel presentation mechanism is used, Ab SHOULD be indicated in the vector.
+
+**NOTE: We could build a table to help readers distinguish between values that are required in the vector (SHALLs/depending on implementation) vs. encouraged (SHOULDs/depending on implementation). I can also add in references to A-C as relevant/appropriate so readers can easily find related guidance.**

--- a/sp800-63d/vot_mapping.md
+++ b/sp800-63d/vot_mapping.md
@@ -2,10 +2,12 @@
 
 <div class="breaker"></div>
 
-## Mapping Assurance Levels to Vectors of Trust
+## Mapping SP 800-63 to Vectors of Trust
 _This section is normative._
 
-Vectors of Trust (VoT) is a standard for expressing information about an authentication transaction from an IdP to an RP. This information is split into several orthogonal component categories, much in the same way that the assurance levels defined in 800-63 are split into different xAL categories.
+Vectors of Trust (VoT) [[VoT]](https://tools.ietf.org/html/draft-richer-vectors-of-trust-05) is a standard for expressing information about an authentication transaction from an IdP to an RP. This information is split into several orthogonal component categories, similar to the way that the assurance levels defined in SP 800-63 are split into different xAL categories.
+
+This document uses terms as defined in [SP 800-63-3 Appendix A](sp800-63-3.html#def-and-acr). Some definitions differ from those in VoT. Notably, the term "authenticator" herein has the same meaning as "credential" in VoT.
 
 ### Trustmark
 
@@ -13,21 +15,44 @@ The trustmark URI for these definitions is [[ URI for this document ]].
 
 ### VoT Components
 
-This document uses the four components defined in VoT: Identity Proofing (P), Primary Credential Usage (C), Primary Credential Management (M), and Assertion Presentation (A).
+This document uses the four components defined in VoT: Identity Proofing (P), Primary Credential Usage (C), Primary Credential Management (M), and Assertion Presentation (A). This document does not define any additional component categories.
 
-The VoT components P, C, and A correspond to 800-63's Identity Assurance Level (IAL), Authenticator Assurance Level (AAL), and Federation Assurance Level (FAL), respectively. While M does not correspond directly to an 800-63 assurance level category, this document defines a set of M values derived from requirements and recommendations in 800-63. This document does not define any additional component categories.
+The VoT [component P](https://tools.ietf.org/html/draft-richer-vectors-of-trust-05#section-2.1) corresponds to identity proofing requirements and recommendations found in [SP 800-63A](sp800-63a.html). As such, the document maps SP 800-63's Identity Assurance Level (IAL) and identity proofing characteristics into VoT's P.
 
-This document uses terms as defined in 800-63-3, Appendix A - Definitions and Abbreviations. Some definitions differ from those in VoT. Notably, the term "authenticator" herein has the same meaning as "credential" in VoT.
+The VoT [component C](https://tools.ietf.org/html/draft-richer-vectors-of-trust-05#section-2.2) corresponds to authentication requirements and recommendations found in [SP 800-63B](sp800-63b.html). As such, this document maps SP 800-63's Authenticator Assurance Level (AAL), authenticator types, and authentication characteristics into VoT's C.
+
+The VoT [component M](https://tools.ietf.org/html/draft-richer-vectors-of-trust-05#section-2.3) corresponds to authenticator lifecycle management requirements and recommendations found in [SP 800-63B Section 6](sp800-63b.html#sec6). As such, this document maps SP 800-63's authenticator lifecycle management characteristics into VoT's M.
+
+The VoT [component A](https://tools.ietf.org/html/draft-richer-vectors-of-trust-05#section-2.4) corresponds to federation requirements and recommendations found in [SP 800-63C](sp800-63c.html). As such, this document maps SP 800-63's Federation Assurance Level (FAL) and assertion presentation into VoT's A.
+
+**Table: 800-63 General Mapping to VoT Components**
+
+|VoT Component|SP 800-63 xAL|SP 800-63 Requirements and Recommendations|
+|:----:|:--:|:--:|
+|P|IAL|identity proofing characteristics|
+|C|AAL|authenticator types and authentication characteristics|
+|M|-|authenticator lifecycle management characteristics|
+|A|FAL|assertion presentation|
 
 ## Component Values
 
-This document defines new component values in accordance with Section 8 of VoT.
+This document defines new component values in accordance with [VoT Section 2](https://tools.ietf.org/html/draft-richer-vectors-of-trust-05#section-2).
+
+The component values for IAL, AAL, and FAL are expressed with numeric identifiers. Only one numeric identifier SHALL be used for each xAL. The implemented IAL, AAL, and/or FAL SHALL be indicated in the vector. Other digital identity information (i.e., identity proofing characteristics, authenticator type(s) used, authentication characteristics, authenticator lifecycle management characteristics, and assertion presentation values) are expressed with alphabetic identifiers. Multiple alphabetic identifiers MAY be used simultaneously. Some alphabetically-expressed values SHALL be indicated in the vector if implementation matches the uses described in the following sections; otherwise, these values MAY be indicated in the vector.
+
+Identity proofing characteristics, authenticator type(s) used, authentication characteristics, and assertion presentation values SHOULD NOT be indicated when they demonstrate the implementation of approaches required under the xAL indicated in the vector. Such approaches are assumed to be implemented per the xAL's requirements. Approaches, as described in the "Use" sections below, that are required under a specific xAL, and SHOULD NOT be indicated in the vector to avoid redundancy, are noted in the "Implied by xAL" column.
+
+**Example:** C2.Cv could be asserted if implementing AAL2 and an authenticator is used that provides verifier impersonation resistance, since verifier impersonation resistance is not required under AAL2.
+
+> Note: Any discrepancies in the assessed and implemented assurance level SHOULD be documented in a digital identity acceptance statement, per [SP 800-63-3 Section 5.5](sp800-63-3.html#daps).
+
+Any additional component categories SHALL NOT be used.
 
 ### Identity Proofing
 
-IAL maps into the VoT component P using a numeric identifier. Identity proofing characteristics map into P using an alphabetic identifier.
+This section defines a series of P component values dervied from [SP 800-63A](sp800-63a.html).
 
-#### IAL to VoT
+#### IAL Values
 
 |IAL|Component Value|
 |:----:|:--:|
@@ -36,25 +61,37 @@ IAL maps into the VoT component P using a numeric identifier. Identity proofing 
 |IAL2|P2|
 |IAL3|P3|
 
-#### Identity Proofing Characteristics
+#### Identity Proofing Characteristic Values
 
-|Identity Proofing Characteristic|Component Value|
-|:----:|:--:|
-|In-person|Pi|
-|Remote|Pr|
-|Knowledge-based Verification (KBV)|Pk|
-|Address Confirmation with Postal Address|Pa|
-|Trusted Referee|Pt|
-|Additional features implemented beyond requirements for asserted IAL|Px|
-|**NOTE: We don't think Px conveys very much - because which values represent "approaches beyond those required under the asserted IAL"? Suggest removing this value. Does this comment also apply to Ax for federation?**||
+|Identity Proofing Characteristic|Component Value|Implied in xAL|
+|:----:|:--:|:--:|
+|In-person Proofing|Pi|IAL3|
+|Unsupervised Remote Proofing|Pr|-|
+|Knowledge-based Verification (KBV)|Pk|-|
+|Address Confirmation with Postal Address|Pa|-|
+|Trusted Referee|Pt|-|
 
->Note: Any credential service provider performing identity proofing at IAL2 or IAL3 MUST conduct a privacy risk assessment. Trusted referee policy and procedures MUST be documented per SP 800-63A Section 5.3.4.
+>Note: Any credential service provider performing identity proofing at IAL2 or IAL3 MUST conduct a privacy risk assessment per [SP 800-63A Section 4.2](sp800-63a.html#genProofReqs). Trusted referee policy and procedures MUST be documented per [SP 800-63A Section 5.3.4](sp800-63a.html#trustref).
 
-### Authenticator Usage
+#### Use of Identity Proofing Values
 
-AAL maps into the VoT component C using a numeric identifier. Authenticator types and characteristics map into C using an alphabetic identifier.
+If KBV is used for identity verification, Pk SHALL be indicated in the vector.
 
-#### AAL to VoT
+**Example:** P2.Pk would be asserted if implementing IAL2 and using KBV for identity verification.
+
+If using a trusted referee acting on behalf of the applicant in the identity proofing process, Pt SHALL be indicated in the vector.
+
+If the subscriber is identity proofed in-person, Pi SHOULD be indicated in the vector.
+
+If the subscriber is identity proofed using an unsupervised remote process, Pr SHOULD be indicated in the vector.
+
+If confirming an applicant's address by sending an enrollment code to a postal address, Pa SHOULD be indicated in the vector.
+
+### Authentication Events
+
+This section defines a series of C component values dervied from [SP 800-63B](sp800-63b.html).
+
+#### AAL Values
 
 |AAL|Component Value|
 |:----:|:--:|
@@ -62,97 +99,39 @@ AAL maps into the VoT component C using a numeric identifier. Authenticator type
 |AAL2|C2|
 |AAL3|C3|
 
-#### Authenticator Types
+#### Authenticator Type Values
 
-|Authenticator Type|Component Value|
-|:----:|:--:|
-|Memorized Secret|Cc|
-|Look-up Secret|Cu|
-|Out-of-band Device|Co|
-|Single-factor OTP|Ca|
-|Multi-factor OTP|Cb|
-|Single-factor Cryptographic Software|Cd|
-|Single-factor Cryptographic Device|Ce|
-|Multi-factor Cryptographic Software|Cf|
-|Multi-factor Cryptographic Device|Cg|
-|Restricted Authenticator|Cr|
+|Authenticator Type|Component Value|Implied in xAL|
+|:----:|:--:|:--:|
+|Memorized Secret|Cc|-|
+|Look-up Secret|Cu|-|
+|Out-of-band Device|Co|-|
+|Single-factor OTP|Ca|-|
+|Multi-factor OTP|Cb|-|
+|Single-factor Cryptographic Software|Cd|-|
+|Single-factor Cryptographic Device|Ce|-|
+|Multi-factor Cryptographic Software|Cf|-|
+|Multi-factor Cryptographic Device|Cg|-|
+|Restricted Authenticator|Cr|-|
 
-#### Authentication Characteristics
+#### Authentication Characteristic Values
 
-|Authentication Characteristic|Component Value|
-|:----:|:--:|
-|FIPS 140 Validation|Ci|
-|Man-in-the-middle Attack Resistance|Cm|
-|Verifier Impersonation Resistance|Cv|
-|Verifier Compromise Resistance|Cs|
-|Authentication Intent|Cn|
-|Additional features implemented beyond requirements for asserted AAL|Cx|
-|Presentation Attack Detection (PAD)|Ck|
-|Biometric comparison performed centrally|Ct|
+|Authentication Characteristic|Component Value|Implied in xAL|
+|:----:|:--:|:--:|
+|FIPS 140 Validation|Ci|AAL3|
+|Verifier Impersonation Resistance|Cv|AAL3|
+|Verifier Compromise Resistance|Cs|AAL3|
+|Authentication Intent|Cn|AAL3|
+|Presentation Attack Detection (PAD)|Ck|-|
+|Biometric comparison performed centrally|Ct|-|
+
+**NOTE: Should we add a vector value for FMR?**
 
 >Note: Some authentication approaches described in Table XX are not applicable for all three AALs.
 
-### Authenticator Lifecycle Management to VoT
+#### Use of Authentication Event Values
 
-Authenticator lifecyle management characteristics, per 800-63B Section 6, map into the VoT component M using an alphabetic identifier.
-
-|Authenticator Lifecycle Management Characteristic|Component Value|
-|:----:|:--:|
-|Authenticator issued/bound during proofing session|Mp|
-|Authenticator issued/bound after proofing session (remote)|Mr|
-|Authenticator issued/bound after proofing session (in-person)|Mi|
-|Second factor bound to a single-factor account|Ms|
-|Authentication factors reestablished (account recovery) using abbreviated proofing process|Ma|
-
-### Federation and Assertions
-
-FAL maps into the VoT component A using a numeric identifier. Assertion presentation maps into A using an alphabetic identifier.
-
-#### FAL to VoT
-
-|FAL|Component Value|
-|:----:|:--:|
-|FAL1|A1|
-|FAL2|A2|
-|FAL3|A3|
-
-#### Assertion Presentation
-
-|Presentation|Component Value|
-|:----:|:--:|
-|Front channel|Af|
-|Back channel|Ab|
-|Additional features implemented beyond requirements for asserted FAL|Ax|
-
-## How to Use the Values in Vectors
-
-The implemented IAL, AAL, and/or FAL component value(s) SHALL be indicated in the vector. Only one numeric identifier SHALL be used for each xAL. Any discrepancies in the assessed and implemented assurance level SHOULD be documented in a digital identity acceptance statement, per SP 800-63-3 Section 5.5.
-
-Identity proofing characteristics, authenticator type(s) used, authentication characteristics, authenticator lifecycle management characteristics, and assertion presentation values MAY be indicated in the vector. Per the requirements in the following sections, some of these values SHALL be indicated in the vector depending on the approaches implemented. Multiple alphabetic identifiers MAY be used simultaneously. 
-
-Identity proofing characteristics, authenticator type(s) used, authentication characteristics, and assertion presentation values SHOULD be indicated only when they demonstrate the implementation of approaches beyond those required by the xAL indicated in the vector. The appropriate value that signifies this (i.e., Px, Cx, and Ax) SHOULD also be indicated. Values SHOULD NOT be indicated that represent approaches already required by the xAL indicated in the vector. These approaches are assumed to be implemented per the xAL's requirements. 
-
-**Example:** C2.Cx.Cv could be asserted if implementing AAL2 and an authenticator is used that provides verifier impersonation resistance, since verifier impersonation resistance is not required under AAL2.
-
-Any additional component categories SHALL NOT be used.
-
-### Identity Proofing Characteristics
-
-If implementing IAL2 and KBV is used for identity verification, Pk SHALL be indicated in the vector (e.g., P2.Pk).
-
-If using a trusted referee acting on behalf of the applicant in the identity proofing process, Pt SHALL be indicated in the vector.
-
-If the subscriber is identity proofed in-person, Pi SHOULD be indicated in the vector.
-
-If the subscriber is identity proofed remotely, Pr SHOULD be indicated in the vector.
-
-If confirming an applicant's address by sending an enrollment code to a postal address, Pa SHOULD be indicated in the vector.
-
-### Authenticator Types
-
-The authenticator type(s) used SHALL be indicated in the vector with the following exceptions.
-
-If implementing AAL3 and authentication is achieved using one of the following two options, the authenticator types used MAY NOT be indicated in the vector.
+The authenticator type(s) used SHALL be indicated in the vector, unless implementing AAL3 and authentication is achieved using one of the following two options.
 
 * Multi-Factor Cryptographic Device; OR
 * Single-Factor Cryptographic Device used in conjunction with Memorized Secret
@@ -161,8 +140,6 @@ If the user authenticates using a restricted authenticator, Cr and the value rep
 
 **Example:** Cr.Co would be asserted if the user authenticates using a secret sent via SMS to an out-of-band device.
 
-### Authentication Characteristics
-
 If implementing AAL1 or AAL2, and:
 
 * the user authenticates with an authenticator that provides verifier impersonation resistance, Cv SHOULD be indicated in the vector.
@@ -170,18 +147,26 @@ If implementing AAL1 or AAL2, and:
 * authentication intent from at least one authenticator is demonstrated, Cn SHOULD be indicated in the vector.
 * for non-government agency authenticators and verifiers, authenticator(s) or verifier(s) are validated to meet the requirements of FIPS 140 Level 1, Ci SHOULD be indicated in the vector.
 
-If using a biometric for authentication, and:
+If the user authenticates using a biometric authenticator, and:
 
-* biometric comparison is performed centrally (not locally on the claimant's device), Ck SHALL be indicated in the vector.
+* biometric comparison is performed centrally (not locally on the claimant's device), Ct SHALL be indicated in the vector.
 * the biometric system implements PAD, Ck SHOULD be indicated in the vector.
 
-**NOTE: Should we add a vector value for FMR?**
-
-MitM attack resistance
-
-**NOTE: I'm struggling to find the case where a MitM resistance value is interesting - it seems to be required most of the time and would be redundant with the xAL indicated in the vector.**
-
 ### Authenticator Lifecycle Management
+
+This section defines a set of M component values dervied from [SP 800-63B Section 6](sp800-63b.html#sec6). The values in this section differ from others in this document because they pertain to the ongoing policy for the account instead of to a specific authentication event.
+
+#### Authenticator Lifecycle Management Characteristic Values
+
+|Authenticator Lifecycle Management Characteristic|Component Value|Implied in xAL|
+|:----:|:--:|:--:|
+|Authenticator issued/bound during proofing session|Mp|-|
+|Authenticator issued/bound after proofing session (remote)|Mr|-|
+|Authenticator issued/bound after proofing session (in-person)|Mi|-|
+|Second factor bound to a single-factor account|Ms|-|
+|Authentication factors reestablished (account recovery) using abbreviated proofing process|Ma|-|
+
+#### Use of Authenticator Lifecycle Management Values
 
 If the authenticator(s) is/are bound/issued:
 
@@ -193,12 +178,86 @@ If the subscriber's account had only one authentication factor bound to it at ac
 
 **NOTE: I don't think the phrasing is quite right on adding a second factor yet.**
 
-If a subscriber loses all authentictors of a factor necessary to complete multi-factor authentication, has been identity proofed at IAL2 or IAL3, and consequently undergoes an abbreviated identity proofing process to reestablish authentication factors, Ma SHALL be indicated in the vector.
+If the following conditions are met, Ma SHALL be indicated in the vector.
 
-### Assertion Presentation
+* The subscriber has been identity proofed at IAL2 or IAL3.
+* The subscriber loses all authenticators of a factor necessary to complete multi-factor authentication. 
+* The subsriber consequently undergoes an abbreviated identity proofing process to reestablish authentication factors.
+
+### Federation and Assertions
+
+This section defines a series of A component values dervied from [SP 800-63C](sp800-63c.html).
+
+#### FAL Values
+
+|FAL|Component Value|
+|:----:|:--:|
+|FAL1|A1|
+|FAL2|A2|
+|FAL3|A3|
+
+#### Assertion Presentation Values
+
+|Assertion Presentation|Component Value|Implied in xAL|
+|:----:|:--:|:--:|
+|Front channel|Af|-|
+|Back channel|Ab|-|
+
+#### Use of Assertion Presentation Values
 
 If a front-channel presentation mechanism is used, Af SHOULD be indicated in the vector.
 
 If a back-channel presentation mechanism is used, Ab SHOULD be indicated in the vector.
 
-**NOTE: We could build a table to help readers distinguish between values that are required in the vector (SHALLs/depending on implementation) vs. encouraged (SHOULDs/depending on implementation). I can also add in references to A-C as relevant/appropriate so readers can easily find related guidance.**
+### Summary
+
+The table below describes the values that are required to be indicated when implementation matches the uses described in the above "Use" sections to conform to this publication.
+
+**NOTE: This table gives me a headache. If we do choose to include it, or a better version of it, in the draft, do we want to add column for encouraged values "SHOULDs"? Or are there any ideas for better ways to organize this table?**
+
+|Component Value|Indication in Vector Required*|
+|:----:|:--:|
+|P0|X|
+|P1|X|
+|P2|X|
+|P3|X|
+|Pi|-|
+|Pr|-|
+|Pk|X|
+|Pa|-|
+|Pt|X|
+|C1|X|
+|C2|X|
+|C3|X|
+|Cc|X|
+|Cu|X|
+|Co|X|
+|Ca|X|
+|Cb|X|
+|Cd|X|
+|Ce|X|
+|Cf|X|
+|Cg|X|
+|Cr|X|
+|Ci|-|
+|Cv|-|
+|Cs|-|
+|Cn|-|
+|Ck|X|
+|Ct|-|
+|Mp|X|
+|Mr|X|
+|Mi|X|
+|Ms|X|
+|Ma|X|
+|A1|X|
+|A2|X|
+|A3|X|
+|Af|-|
+|Ab|-|
+
+*This does mean that these values must always be indicated; these values are only required to be indicated when implementation matches the use described in this document's "Use" sections and when the value represents the implemented xAL.
+
+## References
+
+[VoT] Vectors of Trust, April 3, 2017, available at: [https://tools.ietf.org/html/draft-richer-vectors-of-trust-05](https://tools.ietf.org/html/draft-richer-vectors-of-trust-05)


### PR DESCRIPTION
Please note, this proposed guidance is for discussion purposes. For example, this version suggests that users should not include values that describe requirements under the asserted xAL, but perhaps we should adjust. I've also bolded other notes throughout for consideration.