### PR TITLE
make pages slightly more responsive

### DIFF
--- a/static/css/NISTStyle.css
+++ b/static/css/NISTStyle.css
@@ -84,7 +84,8 @@ sub{
 }
 
 img{
-	border:0
+	border:0;
+	max-width: 100%;
 }
 
 svg:not(:root){
@@ -318,7 +319,9 @@ input,button,select,textarea{
 
 a{
 	color:#0000FF;
-	text-decoration:none
+	text-decoration:none;
+	overflow-wrap: break-word;
+  	word-wrap: break-word;
 }
 
 a:hover,a:focus{
@@ -1634,7 +1637,9 @@ pre code{
 
 table{
 	max-width:100%;
-	background-color:transparent
+	background-color:transparent;
+	display: block;
+	overflow: scroll;
 }
 
 th{


### PR DESCRIPTION
Some pages, specifically https://pages.nist.gov/800-63-3/sp800-63b.html, render really poorly on mobile due to x-axis overflows. This PR makes some minor changes to improve the situation, though the NavBar should probably be hidden or moved off the left edge to improve things further.