### PR TITLE
Revert "make pages slightly more responsive"

### DIFF
--- a/static/css/NISTStyle.css
+++ b/static/css/NISTStyle.css
@@ -84,8 +84,7 @@ sub{
 }
 
 img{
-	border:0;
-	max-width: 100%;
+	border:0
 }
 
 svg:not(:root){
@@ -319,9 +318,7 @@ input,button,select,textarea{
 
 a{
 	color:#0000FF;
-	text-decoration:none;
-	overflow-wrap: break-word;
-  	word-wrap: break-word;
+	text-decoration:none
 }
 
 a:hover,a:focus{
@@ -1637,9 +1634,7 @@ pre code{
 
 table{
 	max-width:100%;
-	background-color:transparent;
-	display: block;
-	overflow: scroll;
+	background-color:transparent
 }
 
 th{


### PR DESCRIPTION
Reverts usnistgov/800-63-3#1891

It doesn't appear that this resolves the rendering issue on small devices (e.g., iPhones), and it seems to cause minor changes to some pages (e.g., alignment of authors' names on the second title pages).

Since it doesn't seem to fix the problem, it's safest to revert to avoid any unintended side effects.