### PR TITLE
Remove "comment period closed" issue template.

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,0 @@
-## SP 800-63-3 Public Comment Period has closed!
-
-The editorial team is in the process of incorporating responses to the comments and completing editing of the documents. All further issues received will be automatically closed.
-
-Thank you for your interest in supporting and improving NIST SP 800-63-3.


### PR DESCRIPTION
It should already be obvious to submitters that the comment period has
long since closed, and this discourages people from submitting new
issues.

Edits are welcome on this PR.